### PR TITLE
Support translucent color for ChromeLikeFilter

### DIFF
--- a/easylauncher/src/main/kotlin/com/project/starter/easylauncher/filter/ChromeLikeFilter.kt
+++ b/easylauncher/src/main/kotlin/com/project/starter/easylauncher/filter/ChromeLikeFilter.kt
@@ -55,7 +55,7 @@ class ChromeLikeFilter(
         // draw the ribbon
         graphics.color = ribbonColor
         if (!adaptive) {
-            graphics.composite = AlphaComposite.getInstance(AlphaComposite.SRC_IN, 1f)
+            graphics.composite = AlphaComposite.getInstance(AlphaComposite.SRC_ATOP, 1f)
         }
         when (gravity) {
             Gravity.TOP -> graphics.fillRect(0, 0, image.width, backgroundHeight)


### PR DESCRIPTION
Fixes #136

![chromelike_alpha](https://user-images.githubusercontent.com/790875/112721796-3794b380-8f06-11eb-8cfd-e233d1092f8b.PNG)
