### PR TITLE
Update Gradle Wrapper from 7.3 to 7.3.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle Wrapper from 7.3 to 7.3.1.

Read the release notes: https://docs.gradle.org/7.3.1/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `7.3.1`
- Distribution (-all) zip checksum: `b75392c5625a88bccd58a574552a5a323edca82dab5942d2d41097f809c6bcce`
- Wrapper JAR Checksum: `33ad4583fd7ee156f533778736fa1b4940bd83b433934d1cc4e9f608e99a6a89`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>