### PR TITLE
Proposal: Port plugin to AndroidComponentsExtension

### DIFF
--- a/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/EasyLauncherPlugin.kt
+++ b/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/EasyLauncherPlugin.kt
@@ -1,14 +1,13 @@
 package com.project.starter.easylauncher.plugin
 
-import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.api.BaseVariant
-import com.project.starter.easylauncher.filter.EasyLauncherFilter
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet
+import com.android.build.gradle.internal.api.DefaultAndroidSourceFile
+import com.android.build.gradle.internal.scope.InternalArtifactType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.TaskProvider
+import org.gradle.configurationcache.extensions.capitalized
 import java.io.File
-import java.util.Locale
 
 class EasyLauncherPlugin : Plugin<Project> {
 
@@ -17,126 +16,119 @@ class EasyLauncherPlugin : Plugin<Project> {
 
         logger.info("Running gradle version: ${gradle.gradleVersion}")
 
-        configureSupportedPlugins { variants ->
-            val android = extensions.getByType(BaseExtension::class.java)
+        val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
 
-            val easyLauncherTasks = mutableListOf<TaskProvider<EasyLauncherTask>>()
+        val manifestBySourceSet = mutableMapOf<String, File>()
+        val resSourceDirectoriesBySourceSet = mutableMapOf<String, Set<File>>()
 
-            variants.configureEach { variant ->
-                val configs = extension.variants.filter { it.name == variant.name }.takeIf { it.isNotEmpty() }
-                    ?: findConfigs(variant, extension.productFlavors, extension.buildTypes)
+        androidComponents.finalizeDsl { common ->
+            common.sourceSets
+                .mapNotNull { sourceSet ->
+                    (sourceSet.manifest as? DefaultAndroidSourceFile)?.srcFile?.let {
+                        Pair(sourceSet.name, it)
+                    }
+                }
+                .forEach {
+                    manifestBySourceSet[it.first] = it.second
+                }
 
-                val enabled = configs.all { it.enabled.get() }
+            common.sourceSets
+                .map { sourceSet ->
+                    val sourceDirs = (sourceSet.res as? DefaultAndroidSourceDirectorySet)?.srcDirs ?: emptySet()
+                    Pair(sourceSet.name, sourceDirs)
+                }
+                .forEach {
+                    resSourceDirectoriesBySourceSet[it.first] = it.second
+                }
+        }
 
-                if (enabled) {
-                    val filters = configs.flatMap { it.filters.get() }.toMutableSet()
+        androidComponents.onVariants { variant ->
+            val configs = extension.variants.filter { it.name == variant.name }.takeIf { it.isNotEmpty() }
+                ?: findConfigs(variant, extension.productFlavors, extension.buildTypes)
 
-                    // set default ribbon
-                    if (filters.isEmpty() && variant.buildType.isDebuggable) {
-                        val ribbonText = when (extension.isDefaultFlavorNaming.orNull) {
-                            true -> variant.flavorName
-                            false -> variant.buildType.name
-                            null ->
-                                if (variant.productFlavors.isEmpty()) {
-                                    variant.buildType.name
-                                } else {
-                                    variant.flavorName
-                                }
-                        }
+            val enabled = configs.all { it.enabled.get() }
+
+            if (enabled) {
+                val filters = configs.flatMap { it.filters.get() }.toMutableSet()
+
+                // set default ribbon
+                if (filters.isEmpty() /*&& variant.buildType.isDebuggable*/) { // TODO: API does not seem to have any way to query the debug flag of the build type
+                    val ribbonText = when (extension.isDefaultFlavorNaming.orNull) {
+                        true -> variant.flavorName
+                        false -> variant.buildType
+                        null ->
+                            if (variant.productFlavors.isEmpty()) {
+                                variant.buildType
+                            } else {
+                                variant.flavorName
+                            }
+                    }
+
+                    if (ribbonText != null) {
                         filters.add(EasyLauncherConfig(ribbonText, project.objects).greenRibbonFilter())
                     }
+                }
 
-                    if (filters.isNotEmpty()) {
-                        val customIconNames = provider {
-                            val global = extension.iconNames.orNull.orEmpty()
-                            val variantSpecific = configs.flatMap { config -> config.iconNames.orNull.orEmpty() }
-                            (global + variantSpecific).toSet()
+                if (filters.isNotEmpty()) {
+                    val customIconNames = provider {
+                        val global = extension.iconNames.orNull.orEmpty()
+                        val variantSpecific = configs.flatMap { config -> config.iconNames.orNull.orEmpty() }
+                        (global + variantSpecific).toSet()
+                    }
+
+                    val relevantSourcesSets = setOfNotNull(
+                        "main",
+                        variant.name,
+                        variant.buildType,
+                        variant.flavorName
+                    )
+
+                    val manifests = manifestBySourceSet
+                        .mapNotNull { (name, file) ->
+                            if (relevantSourcesSets.contains(name)) {
+                                file
+                            } else {
+                                null
+                            }
                         }
 
-                        val task = registerTask(
-                            android = android,
-                            variant = variant,
-                            customIconNames = customIconNames,
-                            filters = filters,
-                        )
+                    val resSourceDirectories = resSourceDirectoriesBySourceSet
+                        .mapNotNull { (name, files) ->
+                            if (relevantSourcesSets.contains(name)) {
+                                files
+                            } else {
+                                null
+                            }
+                        }
+                        .flatten()
 
-                        easyLauncherTasks.add(task)
-
-                        tasks.named("generate${variant.name.capitalize(Locale.ROOT)}Resources") { it.dependsOn(task) }
+                    val task = project.tasks.register("easylauncher${variant.name.capitalized()}", EasyLauncherTask::class.java) {
+                        it.manifestFiles.set(manifests)
+                        it.manifestPlaceholders.set(variant.manifestPlaceholders)
+                        it.resourceDirectories.set(resSourceDirectories)
+                        it.filters.set(filters)
+                        it.customIconNames.set(customIconNames)
+                        it.minSdkVersion.set(variant.minSdkVersion.apiLevel)
                     }
-                } else {
-                    logger.info("disabled for ${variant.name}")
+
+                    variant
+                        .artifacts
+                        .use(task)
+                        .wiredWith(EasyLauncherTask::outputDir)
+                        .toCreate(InternalArtifactType.GENERATED_RES)
                 }
+            } else {
+                logger.info("disabled for ${variant.name}")
             }
-
-            tasks.register(EasyLauncherTask.NAME) { it.dependsOn(easyLauncherTasks) }
-        }
-    }
-
-    private fun Project.registerTask(
-        android: BaseExtension,
-        variant: BaseVariant,
-        customIconNames: Provider<Set<String>>,
-        filters: Set<EasyLauncherFilter>,
-    ): TaskProvider<EasyLauncherTask> {
-        val generatedResDir = getGeneratedResDir(variant)
-        android.sourceSets.getByName(variant.name).res.srcDir(generatedResDir)
-
-        val icons = provider {
-            val names = (customIconNames.get().takeIf { it.isNotEmpty() } ?: android.getLauncherIconNames(variant)).toSet()
-            logger.info("will process icons: ${names.joinToString()}")
-
-            variant.getAllResDirectories(except = generatedResDir).flatMap { resDir ->
-                names.flatMap { objects.getIconFiles(parent = resDir, iconName = it) }
-            }
-        }
-        val minSdkVersion = provider {
-            (variant.mergedFlavor.minSdkVersion ?: android.defaultConfig.minSdkVersion)?.apiLevel ?: 1
-        }
-
-        val name = "${EasyLauncherTask.NAME}${variant.name.capitalize(Locale.ROOT)}"
-
-        // They don't care: https://issuetracker.google.com/issues/187096666 🤷‍
-        // Discussion: https://github.com/usefulness/easylauncher-gradle-plugin/issues/165
-        val extractDeeplinksTask = name.replace("easylauncher", "extractDeepLinks")
-        // Workaround for: https://github.com/gradle/gradle/issues/8057
-        if (tasks.names.contains(extractDeeplinksTask)) {
-            tasks.named(extractDeeplinksTask).configure { it.dependsOn(name) }
-        }
-
-        return tasks.register(name, EasyLauncherTask::class.java) {
-            it.outputDir.set(generatedResDir)
-            it.filters.set(filters)
-            it.minSdkVersion.set(minSdkVersion)
-            it.icons.from(icons)
-            it.resourceDirectories.from(variant.getAllResDirectories(except = generatedResDir))
         }
     }
 
     private fun findConfigs(
-        variant: BaseVariant,
+        variant: com.android.build.api.variant.Variant,
         ribbonProductFlavors: Iterable<EasyLauncherConfig>,
         ribbonBuildTypes: Iterable<EasyLauncherConfig>,
-    ): List<EasyLauncherConfig> =
-        ribbonProductFlavors.filter { config -> variant.productFlavors.any { config.name == it.name } } +
-            ribbonBuildTypes.filter { it.name == variant.buildType.name }
-
-    private fun Project.getGeneratedResDir(variant: BaseVariant) =
-        File(project.buildDir, "generated/easylauncher/res/${variant.name}")
-
-    private fun BaseExtension.getLauncherIconNames(variant: BaseVariant) =
-        getAndroidManifestFiles(variant)
-            .flatMap { manifestFile -> manifestFile.getLauncherIcons(variant.mergedFlavor.manifestPlaceholders) }
-
-    private fun BaseVariant.getAllResDirectories(except: File) =
-        sourceSets.flatMap { sourceSet -> sourceSet.resDirectories }
-            .filterNot { resDirectory -> resDirectory == except }
-
-    private fun BaseExtension.getAndroidManifestFiles(variant: BaseVariant): Iterable<File> {
-        return listOf("main", variant.name, variant.buildType.name, variant.flavorName)
-            .filter { it.isNotEmpty() }
-            .distinct()
-            .map { name -> sourceSets.getByName(name).manifest.srcFile }
-            .filter { it.exists() }
+    ): List<EasyLauncherConfig> {
+        return ribbonProductFlavors.filter { config -> variant.productFlavors.any { config.name == it.second } } +
+            ribbonBuildTypes.filter { it.name == variant.buildType }
     }
 }

--- a/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/EasyLauncherTask.kt
+++ b/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/EasyLauncherTask.kt
@@ -3,51 +3,52 @@ package com.project.starter.easylauncher.plugin
 import com.project.starter.easylauncher.filter.EasyLauncherFilter
 import com.project.starter.easylauncher.plugin.models.AdaptiveIcon
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.file.*
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import javax.inject.Inject
 import kotlin.system.measureTimeMillis
 
 @CacheableTask
-open class EasyLauncherTask @Inject constructor(
-    private val objectFactory: ObjectFactory,
+abstract class EasyLauncherTask @Inject constructor(
+    private val objects: ObjectFactory
 ) : DefaultTask() {
 
-    @OutputDirectory
-    val outputDir: RegularFileProperty = objectFactory.fileProperty()
+    @get:Input
+    abstract val manifestFiles: ListProperty<File>
 
-    @Input
-    val filters: ListProperty<EasyLauncherFilter> = listProperty<EasyLauncherFilter>()
+    @get:Input
+    abstract val manifestPlaceholders: MapProperty<String, String>
 
-    @Input
-    val minSdkVersion: Property<Int> = property(default = null)
+    @get:Input
+    abstract val resourceDirectories: SetProperty<File>
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
-    val resourceDirectories: ConfigurableFileCollection = objectFactory.fileCollection()
+    @get:Input
+    abstract val filters: ListProperty<EasyLauncherFilter>
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
-    val icons: ConfigurableFileCollection = objectFactory.fileCollection()
+    @get:Input
+    abstract val customIconNames: SetProperty<String>
+
+    @get:Input
+    abstract val minSdkVersion: Property<Int>
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
 
     @TaskAction
     fun run() {
-        if (filters.get().isEmpty()) {
-            return
-        }
-
         val taskExecutionTime = measureTimeMillis {
+            val iconNames = customIconNames.get().takeIf { it.isNotEmpty() } ?: getLauncherIconNames()
+            val icons = getIcons(iconNames)
+
             icons.forEach { iconFile ->
                 val adaptiveIcon = iconFile.asAdaptiveIcon()
                 if (adaptiveIcon == null) {
@@ -62,34 +63,48 @@ open class EasyLauncherTask @Inject constructor(
         logger.info("task finished in $taskExecutionTime ms")
     }
 
-    private fun processIcon(adaptiveIcon: AdaptiveIcon) {
-        resourceDirectories.forEach { resDir ->
-            val icons = objectFactory.getIconFiles(parent = resDir, iconName = adaptiveIcon.foreground)
-            icons.forEach { iconFile ->
-                val outputFile = iconFile.getOutputFile()
-                if (iconFile.extension == "xml") {
-                    iconFile.transformXml(outputFile, minSdkVersion.get(), filters.get())
-                } else {
-                    iconFile.transformImage(outputFile, filters.get(), adaptive = true)
-                }
+    private fun getLauncherIconNames(): Set<String> {
+        return manifestFiles
+            .get()
+            .filter { it.exists() }
+            .map {
+                it.getLauncherIcons(manifestPlaceholders.get())
             }
-        }
+            .flatten()
+            .toSet()
     }
 
-    private inline fun <reified T> listProperty(default: Iterable<T> = emptyList()) =
-        objectFactory.listProperty(T::class.java).apply {
-            set(default)
-        }
+    private fun getIcons(iconNames: Set<String>): List<File> {
+        logger.info("will process icons: ${iconNames.joinToString()}")
 
-    private inline fun <reified T> property(default: T? = null) =
-        objectFactory.property(T::class.java).apply {
-            set(default)
-        }
+        return resourceDirectories
+            .get()
+            .filter {
+                it.exists()
+            }
+            .flatMap { resDir ->
+                iconNames.flatMap {
+                    objects.getIconFiles(parent = resDir, iconName = it)
+                }
+            }
+    }
+
+    private fun processIcon(adaptiveIcon: AdaptiveIcon) {
+        resourceDirectories
+            .get()
+            .forEach { resDir ->
+                val icons = objects.getIconFiles(parent = resDir, iconName = adaptiveIcon.foreground)
+                icons.forEach { iconFile ->
+                    val outputFile = iconFile.getOutputFile()
+                    if (iconFile.extension == "xml") {
+                        iconFile.transformXml(outputFile, minSdkVersion.get(), filters.get())
+                    } else {
+                        iconFile.transformImage(outputFile, filters.get(), adaptive = true)
+                    }
+                }
+            }
+    }
 
     private fun File.getOutputFile(): File =
         File(outputDir.asFile.get(), "${parentFile.name}/$name")
-
-    companion object {
-        const val NAME = "easylauncher"
-    }
 }

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -3,3 +3,4 @@ kotlin.code.style=official
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx3g
 org.gradle.caching=true
+android.disableResourceValidation=true


### PR DESCRIPTION
I took some time to debug #349 with AGP 7.3.x and I think the root of the problem is that AGP now ignores the addition of the source set. It seems one can set it fine, but it is just silently ignored. I verified this by setting some break points inside the AGP code during the merge resources task and the easylauncher source set is not there. Any other attempts to fix this failed.

I then stumbled over the AndroidComponentsExtension (https://developer.android.com/reference/tools/gradle-api/4.2/com/android/build/api/extension/AndroidComponentsExtension) which provides an API for what easylauncher actually wants to achieve: create a new source set, use a task to generate some new assets and hook task execution and source set merging into the build process.

This required some refactorings (summarized below), but now the implementation no longer relies on implicit assumptions (such as the name of the merge resources task). As far as I can tell, there are only two regressions for which I have not yet found a solution:
- the project requires setting `android.disableResourceValidation=true`
- the API does not allow to query the isDebuggable flag

Following is a brief summary of changes:
- Move most parts of the processing into the task execution (instead of at configuration time)
  - Manifest parsing
  - Icon file gathering
- Port to AndroidComponentsExtension API
  - Entry point: variant.artifact(...)
  - This tells AGP to execute this task which will generate some resources. The path handling and the task dependencies are automatically taken care of

The sample projects now work again with AGP 7.3.x. Was hoping to get some feedback on this approach and especially the two remaining issues before continuing.
