### PR TITLE
Add ribbon to `<monochrome />` icon

### DIFF
--- a/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/EasyLauncherPlugin.kt
+++ b/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/EasyLauncherPlugin.kt
@@ -115,7 +115,7 @@ class EasyLauncherPlugin : Plugin<Project> {
                         it.resourceDirectories.set(resSourceDirectories)
                         it.filters.set(filters)
                         it.customIconNames.set(customIconNames)
-                        it.minSdkVersion.set(variant.minSdkVersion.apiLevel)
+                        it.minSdkVersion.set(variant.minSdkCompat(agpVersion))
                     }
 
                     if (agpVersion.canUseNewResources) {
@@ -157,3 +157,7 @@ class EasyLauncherPlugin : Plugin<Project> {
     private val AndroidPluginVersion.canUseNewResources get() = this >= AndroidPluginVersion(7, 4).beta(2)
     private val AndroidPluginVersion.hasBrokenResourcesMerging get() = this >= AndroidPluginVersion(7, 3).alpha(1)
 }
+
+@Suppress("DEPRECATION")
+private fun Variant.minSdkCompat(agpVersion: AndroidPluginVersion) =
+    if (agpVersion >= AndroidPluginVersion(8, 1)) minSdk.apiLevel else minSdkVersion.apiLevel

--- a/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/EasyLauncherTask.kt
+++ b/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/EasyLauncherTask.kt
@@ -98,8 +98,11 @@ abstract class EasyLauncherTask @Inject constructor(
 
     private fun IconFile.Adaptive.processAdaptiveIcon() {
         resourceDirectories.get().forEach { resDir ->
-            val icons = objects.getIconFiles(parent = resDir, iconName = foreground)
-            icons.forEach { iconFile ->
+            val foregroundFiles = objects.getIconFiles(parent = resDir, iconName = foreground)
+            val monochromeFiles = monochrome?.let { objects.getIconFiles(parent = resDir, iconName = it) } ?: emptyList()
+            val iconFiles = (foregroundFiles + monochromeFiles).toSet()
+
+            iconFiles.forEach { iconFile ->
                 val outputFile = iconFile.getOutputFile()
                 if (iconFile.extension == "xml") {
                     iconFile.transformXml(outputFile, minSdkVersion.get(), filters.get())

--- a/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/XmlReader.kt
+++ b/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/XmlReader.kt
@@ -31,14 +31,17 @@ internal fun File.tryParseXmlFile(): IconFile? {
     val iconXml = XmlSlurper().parse(this)
     val foreground = iconXml.getProperty("foreground") as GPathResult
     val background = iconXml.getProperty("background") as GPathResult
+    val monochrome = iconXml.getProperty("monochrome") as GPathResult
     val backgroundDrawable = background.property("@android:drawable")
     val foregroundDrawable = foreground.property("@android:drawable")
+    val monochromeDrawable = monochrome.property("@android:drawable")
 
     return if (backgroundDrawable != null && foregroundDrawable != null) {
         IconFile.Adaptive(
             file = this,
             background = backgroundDrawable,
             foreground = foregroundDrawable,
+            monochrome = monochromeDrawable,
         )
     } else {
         IconFile.XmlDrawableResource(file = this)

--- a/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/models/IconFile.kt
+++ b/easylauncher/src/main/kotlin/com/project/starter/easylauncher/plugin/models/IconFile.kt
@@ -8,7 +8,12 @@ internal sealed class IconFile {
 
     data class RasterRound(val file: File) : IconFile()
 
-    data class Adaptive(val file: File, val background: String, val foreground: String) : IconFile()
+    data class Adaptive(
+        val file: File,
+        val background: String,
+        val foreground: String,
+        val monochrome: String?,
+    ) : IconFile()
 
     data class XmlDrawableResource(val file: File) : IconFile()
 }

--- a/easylauncher/src/test/kotlin/com/project/starter/easylauncher/plugin/XmlReaderTest.kt
+++ b/easylauncher/src/test/kotlin/com/project/starter/easylauncher/plugin/XmlReaderTest.kt
@@ -220,6 +220,29 @@ internal class XmlReaderTest {
     }
 
     @Test
+    fun `parses adaptive icon with monochrome option`() {
+        val adaptiveIcon = tempDir.resolve("ic_launcher.xml")
+        adaptiveIcon.writeText(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+                <background android:drawable="@drawable/ic_launcher_background" />
+                <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+                <monochrome android:drawable="@mipmap/ic_launcher_foreground_monochrome" />
+            </adaptive-icon>
+
+            """.trimIndent(),
+        )
+
+        val icon = adaptiveIcon.tryParseXmlFile() as IconFile.Adaptive
+
+        assertThat(icon.background).isEqualTo("@drawable/ic_launcher_background")
+        assertThat(icon.foreground).isEqualTo("@mipmap/ic_launcher_foreground")
+        assertThat(icon.monochrome).isEqualTo("@mipmap/ic_launcher_foreground_monochrome")
+        assertThat(icon.file.path).isEqualTo(adaptiveIcon.path)
+    }
+
+    @Test
     fun `parses drawable resource`() {
         val drawableResource = tempDir.resolve("ic_launcher.xml")
         drawableResource.writeText(vectorFile())


### PR DESCRIPTION
#482

I haven't figured out a way how AGP transforms monochrome icons yet so it doesn't fix the linked issue, but this PR makes the plugin recognize custom icon resource passed via `<monochrome />` tag