### PR TITLE
fix(deps): update com.project.starter:android to 0.96.1 (+ sample fixes)

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -68,8 +68,8 @@ jobs:
         agp: [ alpha, stable ]
         include:
           - javaVersion: 17
-            gradle: "9.0.0"
-            agp: 8.13.2
+            gradle: "9.4.1"
+            agp: 9.2.1
           - javaVersion: 21
             gradle: current
             agp: stable

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.project.starter:android:0.93.0"
+        classpath "com.project.starter:android:0.96.1"
         classpath "io.github.takahirom.roborazzi:roborazzi-gradle-plugin:1.64.0"
         if (project.hasProperty("useMavenLocal")) {
             classpath "com.project.starter.local:easylauncher:+"
@@ -76,6 +76,8 @@ subprojects {
             onVariants(selector().all()) { variant ->
                 variant.applicationId = "com.${project.name.replace("-", ".")}.${variant.name}"
                 variant.manifestPlaceholders.put("appName", "$variant.name")
+                variant.unitTest?.manifestPlaceholders?.put("appName", "$variant.name")
+                variant.androidTest?.manifestPlaceholders?.put("appName", "$variant.name")
             }
         }
 

--- a/sample/icon_check.sh
+++ b/sample/icon_check.sh
@@ -1,6 +1,6 @@
 set -e
 echo "Start"
 ./../gradlew verifyAll --continue
-./../gradlew :example-resources-order:verifyRoborazziLocalCanary
-./../gradlew :example-activity-alias:verifyRoborazziRelease
-./../gradlew :example-activity-alias:verifyRoborazziUnspecified
+./../gradlew :example-resources-order:verifyRoborazziLocalCanary -PtestBuildType=canary
+./../gradlew :example-activity-alias:verifyRoborazziRelease -PtestBuildType=release
+./../gradlew :example-activity-alias:verifyRoborazziUnspecified -PtestBuildType=unspecified


### PR DESCRIPTION
Supersedes #819. Bumps the sample's `com.project.starter:android` plugin **0.93.0 → 0.96.1** and fixes the three breakages that bump surfaces.

starter 0.96.x changes two behaviors that the sample relied on:
- it forces **AGP 9.2.1**, and
- it only generates test/Roborazzi tasks for the active `testBuildType` (default `debug`), whereas 0.93.0 generated them for all build types.

### Changes

1. **`sample/build.gradle`** — set the `appName` manifest placeholder on the `unitTest`/`androidTest` components too. starter 0.96.x processes a separate unit-test manifest; without this, `processXXXDebugUnitTestManifest` fails with *"requires a placeholder substitution but no value for `<appName>` is provided"*. Uses full safe-navigation since `androidTest` is null on non-debug variants.

2. **`.github/workflows/default.yml`** — bump the minimum matrix row from `AGP 8.13.2` / `Gradle 9.0.0` to `AGP 9.2.1` / `Gradle 9.4.1`. The old AGP pin crashed at configure time (`NoSuchMethodError: LibraryExtension.getBuildFeatures()`) because starter 0.96.1 calls a 9.x-only AGP method. AGP 9.2 [requires Gradle ≥ 9.4.1](https://developer.android.com/build/releases/agp-9-2-0-release-notes).

3. **`sample/icon_check.sh`** — pass `-PtestBuildType=<type>` for the `canary`/`release`/`unspecified` verify tasks. Those tasks no longer exist under the default (`debug`) `testBuildType` with starter 0.96.x. (The original #819 CI never reached this — `verifyAll` failed first on the manifest issue.)

### Verification (local, JDK 25 to match CI)
- Previously-failing `:example-vector:processCustomDrawableDebugUnitTestManifest` → passes
- Configure with strict `-PagpVersion=9.2.1` → no `getBuildFeatures` error
- Full `./icon_check.sh` (verifyAll + all 3 build-type verifies) → 4× BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)